### PR TITLE
Simplify APEX schema fetching

### DIFF
--- a/lib/distUpload.js
+++ b/lib/distUpload.js
@@ -92,14 +92,7 @@ for (var file in files) {
         "   from apex_applications" +
         "   where application_id = l_app_id;" +
 
-        "   select " +
-        "       case " +
-        "           when version_no like '5.1%' then 'APEX_050100'" +
-        "           when version_no like '5.0%' then 'APEX_050000'" +
-        "           when version_no like '4.2%' then 'APEX_040200'" +
-        "       end apex_schema" +
-        "   into l_apex_schema    " +
-        "   from apex_release;" +
+        " l_apex_schema := apex_application.g_flow_schema_owner; " +
 
         "   apex_util.set_security_group_id (p_security_group_id => l_workspace_id);" +
         // eliminate the local dist path to get a real file name

--- a/lib/distUpload.js
+++ b/lib/distUpload.js
@@ -92,7 +92,7 @@ for (var file in files) {
         "   from apex_applications" +
         "   where application_id = l_app_id;" +
 
-        " l_apex_schema := apex_application.g_flow_schema_owner; " +
+        "   l_apex_schema := apex_application.g_flow_schema_owner; " +
 
         "   apex_util.set_security_group_id (p_security_group_id => l_workspace_id);" +
         // eliminate the local dist path to get a real file name


### PR DESCRIPTION
Not sure if there's a reason your prefer to use the existing query for determining the APEX schema, but I find I tend to use the property: `apex_application.g_flow_schema_owner;`, which should prove one less part that needs to be maintained as more version come out. 

Just a thought :)

Tested with this change in place, locally:

```
trent@birroth:~/Projects/apex-publish-static-files$ cat run.js
var publisher = require('./index');

publisher.publish({
    sqlclPath: "sql",
    connectString: "vmtest/vmtest@//192.168.0.182:1521/xe",
    directory: "/tmp/vm2",
    appID: 100
});

trent@birroth:~/Projects/apex-publish-static-files$ node run.js 
Uploading to Shared Components - Application Static Files...

SQLcl: Release 4.2.0 Production on Tue Feb 28 23:08:10 2017

Copyright (c) 1982, 2017, Oracle.  All rights reserved.

Connected to:
Oracle Database 11g Express Edition Release 11.2.0.2.0 - 64bit Production

Uploading: /tmp/vm2/test2.txt
Uploading: /tmp/vm2/test.txt

SQL> 
Disconnected from Oracle Database 11g Express Edition Release 11.2.0.2.0 - 64bit Production

Files were uploaded successfully.
```