### PR TITLE
Directory parameter may be a single file

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,7 @@
 # Changelog
+### 2.0.1
+- The `directory` parameter may be a file path as well as a directory
+
 ### 2.0.0
 - Adds Java 9 support
 - Adds support for uploading to plugin files

--- a/index.js
+++ b/index.js
@@ -35,14 +35,21 @@ module.exports = {
 			throw new Error(`Directory ${opts.directory} is not a valid path.`);
 		}
 
-		const getAllFiles = dir =>
-			fs.readdirSync(dir).reduce((files, file) => {
-				const name = path.join(dir, file);
-				const isDirectory = fs.statSync(name).isDirectory();
-				return isDirectory ? [...files, ...getAllFiles(name)] : [...files, name];
-			}, []);
+		const getAllFiles = (files, dir) => {
+			if (fs.lstatSync(dir).isDirectory()) {
+				fs.readdirSync(dir).forEach(file => {
+					let fullPath = path.join(dir, file);
+					getAllFiles(files, fullPath);
+				});
+			} else {
+				files.push(dir);
+			}
+		}
 
-		if (getAllFiles(opts.directory).length === 0) {
+		let files = [];
+		getAllFiles(files, opts.directory);
+
+		if (files.length === 0) {
 			console.log('Directory is empty.');
 		} else {
 			// Execute the upload process

--- a/index.js
+++ b/index.js
@@ -38,15 +38,15 @@ module.exports = {
 		const getAllFiles = (files, dir) => {
 			if (fs.lstatSync(dir).isDirectory()) {
 				fs.readdirSync(dir).forEach(file => {
-					let fullPath = path.join(dir, file);
+					const fullPath = path.join(dir, file);
 					getAllFiles(files, fullPath);
 				});
 			} else {
 				files.push(dir);
 			}
-		}
+		};
 
-		let files = [];
+		const files = [];
 		getAllFiles(files, opts.directory);
 
 		if (files.length === 0) {

--- a/lib/distUpload.js
+++ b/lib/distUpload.js
@@ -27,16 +27,13 @@ helpers.getBlobFromFile = function(fileName) {
 // recursively enters each sub directory and adds the files to the array
 helpers.walkFileTree = function(path) {
 	var cwd = new File(path);
-	var pathFiles = cwd.listFiles();
-
-	for (var f in pathFiles) {
-		if (pathFiles[f].isDirectory()) {
+	if (cwd.isDirectory()) {
+		var pathFiles = cwd.listFiles();
+		for (var f in pathFiles) {
 			helpers.walkFileTree(pathFiles[f].getAbsolutePath());
 		}
-
-		if (pathFiles[f].isFile()) {
-			files[fileCount++] = pathFiles[f];
-		}
+	} else {
+		files[fileCount++] = cwd;
 	}
 };
 
@@ -115,6 +112,7 @@ for (var file in files) {
 		" declare" +
 		"   l_file_name varchar2(4000);" +
 		"   l_mime_type varchar2(4000);" +
+		"   l_path varchar2(4000);" +
 		"   l_dir varchar2(4000);" +
 
 		// app_id is a varchar2 because it can come as an app alias too
@@ -148,11 +146,13 @@ for (var file in files) {
 
 		"   apex_util.set_security_group_id (p_security_group_id => l_workspace_id);" +
 
-		"   l_file_name := :path;" +
+		"   l_path := :path;" +
 		"   l_dir := :dir;" +
 		// eliminate the local dist path to get a real file name
 		// "C:/dist/css/app.css" becomes "css/app.css"
-		"   l_file_name := substr(l_file_name, length(l_dir) + 2);" +
+		"   l_file_name := substr(l_path, length(l_dir) + 2);" +
+		// dir and path are the same for a single file so becomes "app.css"
+		"   l_file_name := coalesce(l_file_name, substr(l_path, instr(l_path, '\\', -1) + 1));" +
 		"   l_file_name := replace(l_file_name, '\\', '/');" +
 
 		// get the mime type for the current file

--- a/package-lock.json
+++ b/package-lock.json
@@ -2810,7 +2810,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2831,12 +2832,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2851,17 +2854,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2978,7 +2984,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2990,6 +2997,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3004,6 +3012,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3011,12 +3020,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -3035,6 +3046,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3115,7 +3127,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3127,6 +3140,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3212,7 +3226,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3248,6 +3263,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3267,6 +3283,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3310,12 +3327,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 [![npm](https://img.shields.io/npm/v/apex-publish-static-files.svg)]() [![Build Status](https://travis-ci.org/vincentmorneau/apex-publish-static-files.svg?branch=master)](https://travis-ci.org/vincentmorneau/apex-publish-static-files) [![Dependency Status](https://david-dm.org/vincentmorneau/apex-publish-static-files.svg)](https://david-dm.org/vincentmorneau/apex-publish-static-files) [![XO code style](https://img.shields.io/badge/code_style-XO-5ed9c7.svg)](https://github.com/sindresorhus/xo)
 
-Uploads all files from a local directory to Oracle APEX. Destination can be:
+Uploads all files from a local directory or a single file to Oracle APEX. Destination can be:
 - Application Static Files
 - Workspace Static Files
 - Theme Files
@@ -35,7 +35,7 @@ Name | Type | Default | Description
 --- | --- | --- | ---
 sqlclPath | string | sql | Path to SQLcl (example: `/Users/vmorneau/sqlcl/bin/sql`)
 connectString | string | | user/pass@server:port/sid
-directory | string | | Local directory that contains the files
+directory | string | | Local directory that contains the files or file path
 appID | numeric | | Application ID to export the files to
 destination | string | | Determines where the files should be uploaded in APEX (choices: `application`, `workspace`, `theme`, `plugin`)
 


### PR DESCRIPTION
Fixes #14.

I expect that the [recursive function that checks whether the directory is empty](https://github.com/tslwn/apex-publish-static-files/blob/single-file/index.js#L38-L50) could be simplified, but otherwise I think the changes are minimal. A minor complication that I had not anticipated is that the name of each file is its path relative to the `directory` parameter. I cannot think of an alternative to the [local file name](https://github.com/tslwn/apex-publish-static-files/blob/single-file/lib/distUpload.js#L151-L156) when publishing a single file.

I have tested all combinations of the parameters using the package alone and as part of a VS Code extension (the impetus for this PR).