### PR TITLE
OCI (Oracle Cloud) TNS_ADMIN definition example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -23,6 +23,9 @@ npm install apex-publish-static-files
 ```javascript
 var publisher = require('apex-publish-static-files');
 
+// If connecting to OCI (Oracle cloud) need to specify location of Oracle Wallet
+process.env['TNS_ADMIN'] = '/Users/vmorneau/oracle/wallets/atp01';
+
 publisher.publish({
     connectString: "user/pass@server:port/sid",
     directory: "/Users/vmorneau/Documents/project/www",


### PR DESCRIPTION
When connection to OCI environments need to define the `TNS_ADMIN` that points to the location of the wallet on client machine.

This could also be an option in the future but thought that just documenting it shows how easy it is to resolve.